### PR TITLE
Validate cookiecutter config overrides to prevent silent fry (fixes #43)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,15 @@
 
 ## 3.0.3 (unreleased)
 
-- No changes yet.
+- Fix: Validate cookiecutter config overrides before project generation.
+  Cookiecutter silently discards every remaining `default_context` override
+  after the first invalid one (e.g. an unparseable boolean from
+  `INSTANCE_log_syslog=""`), producing incomplete `etc/*` files. The
+  pre-generation hook now re-reads `$COOKIECUTTER_CONFIG` (or
+  `~/.cookiecutterrc`), validates each override against the types declared
+  in `cookiecutter.json`, and aborts with an actionable error.
+  [Fixes #43]
+  [@jensens]
 
 ## 3.0.2 (2026-04-03)
 

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -1,4 +1,88 @@
 from collections import OrderedDict
+from pathlib import Path
+
+import json
+import os
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover — cookiecutter depends on PyYAML
+    yaml = None
+
+
+# Up-front validation of cookiecutter config overrides.
+#
+# cookiecutter.generate.apply_overwrites_to_context short-circuits on the
+# first invalid override (e.g. an empty string for a boolean, or an unknown
+# choice). The exception is caught as a UserWarning and ALL remaining
+# overrides in default_context are silently dropped, leaving the project
+# partially configured — incomplete etc/* files. See issue #43.
+#
+# We re-read the cookiecutter config file and validate every override
+# against the declared types in cookiecutter.json, aborting loudly before
+# cookiecutter can silently fry things.
+_YES_NO = {
+    "1", "true", "t", "yes", "y", "on",
+    "0", "false", "f", "no", "n", "off",
+}
+
+
+def _validate_default_context():
+    if yaml is None:
+        return []
+    config_path = os.environ.get("COOKIECUTTER_CONFIG") or os.path.expanduser(
+        "~/.cookiecutterrc"
+    )
+    if not os.path.isfile(config_path):
+        return []
+    try:
+        cfg = yaml.safe_load(Path(config_path).read_text()) or {}
+    except Exception as exc:
+        return [f"could not parse cookiecutter config {config_path}: {exc}"]
+    default_ctx = cfg.get("default_context") or {}
+    if not isinstance(default_ctx, dict):
+        return []
+    template_dir = Path(r"{{ cookiecutter._template }}")
+    cc_json = template_dir / "cookiecutter.json"
+    if not cc_json.is_file():
+        return []
+    try:
+        defaults = json.loads(cc_json.read_text())
+    except Exception:
+        return []
+    errors = []
+    for var, val in default_ctx.items():
+        declared = defaults.get(var)
+        if isinstance(declared, bool):
+            if isinstance(val, bool):
+                continue
+            if not isinstance(val, str) or val.strip().lower() not in _YES_NO:
+                errors.append(
+                    f"{var}={val!r} cannot be parsed as boolean "
+                    f"(use true/false/yes/no/on/off/0/1)"
+                )
+        elif isinstance(declared, list) and declared:
+            # Choice variable. Also treat lists of dicts (nested) as free-form.
+            if all(isinstance(c, (str, int, float, bool)) for c in declared):
+                if val not in declared:
+                    errors.append(
+                        f"{var}={val!r} is not in allowed choices {declared}"
+                    )
+    return errors
+
+
+_override_errors = _validate_default_context()
+if _override_errors:
+    print(
+        "Error: invalid override(s) in cookiecutter default_context detected.\n"
+        "Cookiecutter would silently drop these (and every subsequent override)\n"
+        "via UserWarning, producing incomplete etc/* files.\n"
+        "See https://github.com/plone/cookiecutter-zope-instance/issues/43\n"
+    )
+    for err in _override_errors:
+        print(f"  - {err}")
+    exit(1)
+
 
 # invariant checks
 # check database mode direct and blobs not cache

--- a/tests/test_bake_invalid_overrides.py
+++ b/tests/test_bake_invalid_overrides.py
@@ -1,0 +1,86 @@
+"""Tests for up-front validation of cookiecutter config overrides.
+
+Cookiecutter's :func:`apply_overwrites_to_context` short-circuits on the first
+invalid override (e.g. an unparseable boolean), caught one frame up as a
+``UserWarning`` and silently discards all remaining overrides. The generated
+project ends up with a mix of user-set values and ``cookiecutter.json``
+defaults — "fried" etc/* files, as reported in
+https://github.com/plone/cookiecutter-zope-instance/issues/43.
+
+The pre-generation hook inspects the cookiecutter config file directly and
+aborts with an actionable error before cookiecutter can silently drop
+overrides.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from cookiecutter.exceptions import FailedHookException
+from cookiecutter.main import cookiecutter
+
+
+TEMPLATE = str(Path(__file__).resolve().parent.parent)
+
+
+@pytest.fixture
+def bake(tmp_path, monkeypatch):
+    def _bake(default_context):
+        user_dir = tmp_path / "user"
+        user_dir.mkdir(exist_ok=True)
+        (user_dir / "cc_dir").mkdir(exist_ok=True)
+        (user_dir / "replay").mkdir(exist_ok=True)
+        config_file = user_dir / "config"
+        config_file.write_text(
+            yaml.safe_dump(
+                {
+                    "cookiecutters_dir": str(user_dir / "cc_dir"),
+                    "replay_dir": str(user_dir / "replay"),
+                    "default_context": default_context,
+                }
+            )
+        )
+        output = tmp_path / "out"
+        output.mkdir(exist_ok=True)
+        # COOKIECUTTER_CONFIG lets the pre-gen hook discover the same config
+        # file cookiecutter uses (cookiecutter does not expose the explicit
+        # --config-file argument to hooks).
+        monkeypatch.setenv("COOKIECUTTER_CONFIG", str(config_file))
+        return cookiecutter(
+            TEMPLATE,
+            no_input=True,
+            output_dir=str(output),
+            config_file=str(config_file),
+        )
+
+    return _bake
+
+
+@pytest.mark.parametrize("value", ["", "maybe", "nope", "2", "   "])
+def test_unparseable_boolean_default_aborts(bake, value):
+    with pytest.raises(FailedHookException):
+        bake({"log_syslog": value})
+
+
+@pytest.mark.parametrize(
+    "value", ["true", "True", "yes", "Y", "on", "false", "False", "n", "0", "OFF"]
+)
+def test_parseable_boolean_string_default_succeeds(bake, value):
+    bake({"log_syslog": value})
+
+
+def test_real_boolean_default_succeeds(bake):
+    bake({"log_syslog": False})
+
+
+def test_invalid_choice_default_aborts(bake):
+    with pytest.raises(FailedHookException):
+        bake({"db_storage": "sqlserver"})
+
+
+def test_valid_choice_default_succeeds(bake):
+    bake({"db_storage": "zeo"})
+
+
+def test_no_default_context_succeeds(bake):
+    bake({})


### PR DESCRIPTION
## Summary

- **Root cause (deeper than it looks).** Cookiecutter's [`apply_overwrites_to_context`](https://github.com/cookiecutter/cookiecutter/blob/main/cookiecutter/generate.py) short-circuits the entire override loop on the first invalid entry. The calling frame catches the `ValueError` as `UserWarning: Invalid default received: …` and continues. **Every subsequent override in `default_context` is silently discarded** — not just the one that failed. `INSTANCE_log_syslog=\"\"` doesn't only break `log_syslog`; it abandons every `INSTANCE_*` override that alphabetically follows it, leaving a mix of user intent and `cookiecutter.json` defaults across `etc/*`.
- **Why the existing pre-gen validation can't save you.** By the time `pre_gen_project.py` runs, cookiecutter has already merged (and partially thrown away) the config. Its own checks see the stale defaults, not the lost overrides.
- **The scope is wider than booleans.** The same short-circuit triggers for invalid choice/multichoice overrides (`\"direct\"/\"relstorage\"/\"zeo\"/\"pgjsonb\"`), so any typo in a constrained field silently fries everything after it.

## Fix

The pre-generation hook now independently re-reads the cookiecutter config file — `$COOKIECUTTER_CONFIG` or `~/.cookiecutterrc` — parses its `default_context`, and validates each override against the types declared in `cookiecutter.json` (bool and choice), **naming every invalid override, not just the first**. If anything fails the check, the hook aborts with an actionable error before the fry can happen.

- Bool fields accept real YAML booleans, or strings in cookiecutter's own `YesNoPrompt` vocabulary (`true/false/yes/no/on/off/1/0/t/f/y/n`, case-insensitive).
- Choice fields must match one of the declared options.
- Undeclared types / dicts / free-form strings are left alone.

Limitation: cookiecutter does not expose the explicit `--config-file` CLI argument to hooks. Validation works when the config is discovered via `$COOKIECUTTER_CONFIG` (what the Plone Docker image / `docker-initialize.py` does) or `~/.cookiecutterrc` (the interactive default). CLI users who pass `--config-file` without also setting the env var will still see cookiecutter's own warning — which they can now be told to promote to an error via `PYTHONWARNINGS=error`.

## Test plan

- [x] New test module `tests/test_bake_invalid_overrides.py` — 19 parametrized cases covering:
  - unparseable boolean strings (`\"\"`, `\"maybe\"`, `\"nope\"`, `\"2\"`, `\"   \"`) → abort
  - parseable boolean strings (`true`, `yes`, `Y`, `on`, `false`, `n`, `0`, `OFF`, etc.) → succeed
  - native YAML booleans → succeed
  - invalid `db_storage` choice → abort
  - valid `db_storage=zeo` → succeed
  - empty `default_context` → succeed (baseline)
- [x] Full suite green: `pytest` — **83 passed**.

## Follow-ups (not in this PR)

1. **Upstream cookiecutter**: `apply_overwrites_to_context` should collect per-variable errors and continue, then raise at the end, instead of aborting the loop and getting downgraded to a warning. Worth a separate upstream issue/PR.
2. **plone/plone-backend `docker-initialize.py`**: normalize/validate `INSTANCE_*` env vars before writing them to the YAML — this is where the empty string originates in the most common deployment path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)