### PR TITLE
Docs: sample-configurations reference + runnable backend how-to examples

### DIFF
--- a/docs/sources/how-to/configure-pgjsonb.md
+++ b/docs/sources/how-to/configure-pgjsonb.md
@@ -8,6 +8,7 @@ standard SQL operators.
 
 ## Prerequisites
 
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
 - A running PostgreSQL 14+ server
 - The `zodb-pgjsonb` and `zodb-json-codec` Python packages installed
 - A PostgreSQL database created for your Zope instance
@@ -54,6 +55,9 @@ default_context:
 
 ```yaml
 default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
     initial_user_name: admin
     initial_user_password: admin
 
@@ -67,6 +71,9 @@ default_context:
     # ZODB object cache
     db_cache_size: 50000
 ```
+
+For the full set of annotated sample configurations, including development and
+other backend variants, see {doc}`/reference/sample-configurations`.
 
 ## Optional: S3 tiered blob storage
 

--- a/docs/sources/how-to/configure-relstorage.md
+++ b/docs/sources/how-to/configure-relstorage.md
@@ -9,6 +9,7 @@ horizontal scaling.
 
 ## Prerequisites
 
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
 - A running PostgreSQL server
 - The `RelStorage` and `psycopg2` Python packages installed
 - A PostgreSQL database created for your Zope instance
@@ -66,10 +67,13 @@ default_context:
 
 ## Complete example
 
-Here is a production-ready `instance.yaml` with commonly tuned settings:
+Here is a complete, runnable `instance.yaml` with commonly tuned settings:
 
 ```yaml
 default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
     initial_user_name: admin
     initial_user_password: admin
 
@@ -89,6 +93,9 @@ default_context:
     # Blob cache
     db_blob_cache_size: 10737418240  # 10 GB
 ```
+
+For the full set of annotated sample configurations, including development and
+other backend variants, see {doc}`/reference/sample-configurations`.
 
 ## Generated helper files
 

--- a/docs/sources/how-to/configure-z3blobs.md
+++ b/docs/sources/how-to/configure-z3blobs.md
@@ -7,6 +7,7 @@ This guide walks you through enabling S3-backed blob storage using
 
 ## Prerequisites
 
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
 - The `zodb-s3blobs` Python package installed
 - An S3-compatible storage service (AWS S3, MinIO, Ceph, etc.)
 - A bucket created for your blob data
@@ -55,6 +56,9 @@ default_context:
 
 ```yaml
 default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
     initial_user_name: admin
     initial_user_password: admin
     zcml_package_includes: my.addon
@@ -98,6 +102,8 @@ storage with PGJsonb, use the built-in S3 tiering instead. See
 
 ## Next steps
 
+- {doc}`/reference/sample-configurations` -- Complete, copy-paste
+  configurations for every backend, including the z3blobs wrapper.
 - {doc}`/reference/database-z3blobs` -- Full reference for all z3blobs settings.
 - {doc}`/explanation/blob-handling` -- How blobs work across different backends.
 - {doc}`/explanation/storage-backends` -- Comparison of all storage backends.

--- a/docs/sources/how-to/configure-zeo.md
+++ b/docs/sources/how-to/configure-zeo.md
@@ -8,6 +8,7 @@ Zope application processes to share a single database.
 
 ## Prerequisites
 
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
 - A running ZEO server (see ZODB/ZEO documentation for server setup)
 - The `ZEO` Python package installed
 
@@ -82,6 +83,9 @@ Each client in a multi-instance deployment should have a unique
 
 ```yaml
 default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
     initial_user_name: admin
     initial_user_password: admin
 
@@ -104,6 +108,9 @@ default_context:
     # ZODB object cache
     db_cache_size: 30000
 ```
+
+For the full set of annotated sample configurations, including development and
+other backend variants, see {doc}`/reference/sample-configurations`.
 
 ## Next steps
 

--- a/docs/sources/reference/index.md
+++ b/docs/sources/reference/index.md
@@ -10,6 +10,7 @@ maxdepth: 2
 ---
 base-locations
 basic-config
+sample-configurations
 logging
 initial-user
 zcml

--- a/docs/sources/reference/sample-configurations.md
+++ b/docs/sources/reference/sample-configurations.md
@@ -1,0 +1,172 @@
+# Sample configurations
+
+<!-- diataxis: reference -->
+
+This page collects complete, copy-paste `instance.yaml` configurations, one
+per storage backend, in development and production variants.
+Each configuration is self-contained and generates a working instance as-is.
+
+For step-by-step guidance, see the {doc}`/how-to/index` guides.
+For the trade-offs between backends, see {doc}`/explanation/storage-backends`.
+For the meaning of every individual setting, see the reference pages linked
+from each section below.
+
+:::{important}
+The passwords shown here are placeholders for local use.
+Never commit real credentials.
+In production, set `initial_user_password` and database passwords from the
+environment instead.
+See {doc}`/how-to/use-environment-variables`.
+:::
+
+(sample-filestorage-dev)=
+
+## Filestorage (development)
+
+The minimal configuration.
+A single process opens a local `Data.fs` file directly, with no database
+server.
+This is the base that the other configurations extend.
+
+```yaml
+default_context:
+    # Serving
+    wsgi_listen: localhost:8080
+
+    # Initial admin user
+    initial_user_name: admin
+    initial_user_password: admin
+
+    # Add-ons
+    zcml_package_includes: my.awesome.addon
+
+    # Storage
+    db_storage: direct
+```
+
+See {doc}`database-direct` and {doc}`basic-config`.
+
+(sample-relstorage-prod)=
+
+## RelStorage with PostgreSQL (production)
+
+The recommended backend for production deployments that scale horizontally.
+Pickles are stored in PostgreSQL, and each client keeps a local blob cache.
+
+```yaml
+default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
+    # Initial admin user (override the password from the environment)
+    initial_user_name: admin
+    initial_user_password: admin
+
+    # Add-ons
+    zcml_package_includes: my.awesome.addon
+
+    # Storage
+    db_storage: relstorage
+    db_blob_mode: cache
+    db_relstorage: postgresql
+    db_relstorage_postgresql_dsn: "host='db' dbname='plone' user='plone' password='secret'"
+    db_relstorage_keep_history: false
+
+    # Caches
+    db_cache_size: 50000
+    db_cache_size_bytes: 1500MB
+    db_blob_cache_size: 10737418240  # 10 GB
+```
+
+See {doc}`database-relstorage`, {doc}`database-blobs`, and {doc}`database-common`.
+
+(sample-zeo-prod)=
+
+## ZEO client (production)
+
+A client that connects to a shared ZEO server.
+Blobs are shared through a common directory (for example, an NFS mount).
+Each client in a multi-instance deployment needs a unique `db_zeo_client`.
+
+```yaml
+default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
+    # Initial admin user (override the password from the environment)
+    initial_user_name: admin
+    initial_user_password: admin
+
+    # Add-ons
+    zcml_package_includes: my.awesome.addon
+
+    # Storage
+    db_storage: zeo
+    db_zeo_server: "zeo.example.com:8100"
+
+    # Shared blob directory (for example, an NFS mount)
+    db_blob_mode: shared
+    db_blob_location: /srv/zodb/blobs
+
+    # Persistent client cache (unique name per client)
+    db_zeo_client: web1
+    db_zeo_var: /var/cache/zeo
+    db_zeo_cache_size: 256MB
+
+    # Object cache
+    db_cache_size: 30000
+```
+
+See {doc}`database-zeo`, {doc}`database-blobs`, and {doc}`database-common`.
+
+(sample-pgjsonb-prod)=
+
+## PGJsonb (production)
+
+A cloud-native backend that stores object state as PostgreSQL JSONB.
+Blobs live in PostgreSQL `bytea` by default; the generic `db_blob_*` settings
+do not apply.
+
+```yaml
+default_context:
+    # Serving (bind to localhost when behind a reverse proxy)
+    wsgi_listen: 127.0.0.1:8080
+
+    # Initial admin user (override the password from the environment)
+    initial_user_name: admin
+    initial_user_password: admin
+
+    # Add-ons
+    zcml_package_includes: my.awesome.addon
+
+    # Storage
+    db_storage: pgjsonb
+    db_pgjsonb_dsn: "dbname='zodb' user='zodb' host='db' port='5432'"
+    db_pgjsonb_history_preserving: false
+
+    # Object cache
+    db_cache_size: 50000
+    db_pgjsonb_cache_local_mb: 64
+```
+
+See {doc}`database-pgjsonb` and {doc}`database-common`.
+
+## S3 blob storage (z3blobs wrapper)
+
+The z3blobs wrapper redirects blob handling to S3-compatible object storage.
+It wraps a `direct`, `relstorage`, or `zeo` backend (not `pgjsonb`).
+Add the following keys to any of the configurations above except PGJsonb.
+
+```yaml
+default_context:
+    # ... a direct, relstorage, or zeo configuration from above ...
+
+    # S3 blob wrapper
+    db_z3blobs_enabled: true
+    db_z3blobs_bucket_name: prod-blobs
+    db_z3blobs_cache_dir: /var/cache/s3blobs
+    db_z3blobs_cache_size: 10GB
+    db_z3blobs_s3_region: eu-west-1
+```
+
+See {doc}`database-z3blobs` and {doc}`/explanation/blob-handling`.


### PR DESCRIPTION
Part of #46. Closes #47. Follow-up to the discoverability gap raised in #45.

## What
- **New** `reference/sample-configurations.md` — the single canonical owner of complete, copy-paste `instance.yaml` configs: filestorage (dev), RelStorage+PostgreSQL, ZEO client, PGJsonb, and the z3blobs S3 wrapper. Wired into the reference toctree.
- **Retrofit** the four backend how-tos (`configure-relstorage`, `configure-zeo`, `configure-pgjsonb`, `configure-z3blobs`):
  - "Complete example" blocks now include `wsgi_listen` so they boot end-to-end (this is what was missing when @tkimnguyen couldn't find how to set the port in #45).
  - Added a newcomer prerequisite line linking `{doc}`/tutorials/first-zope-instance``.
  - Added a one-line pointer to the sample-configurations page instead of re-documenting the base config — keeps the base config single-owned and avoids drift.

## Diataxis note
The how-tos keep complete *runnable* examples (legitimate how-to content), while the canonical annotated configs live in one reference page. Single-quadrant purity preserved; no mega-page.

## Verification
- `sphinx-build -n` (nitpicky) — clean, **zero warnings**.
- New page renders; `{doc}` cross-references from the how-tos resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)