### PR TITLE
Docs: how-tos for listen host/port and direct filestorage

### DIFF
--- a/docs/sources/how-to/configure-filestorage.md
+++ b/docs/sources/how-to/configure-filestorage.md
@@ -1,0 +1,94 @@
+# Configure direct filestorage
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to configure the `direct` (FileStorage) backend, in
+which a single process opens a local `Data.fs` file directly without a
+database server.
+This is the default backend and the simplest option for development and
+single-process deployments.
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+
+## Step 1: set the storage type
+
+In your `instance.yaml`, set the storage backend to `direct`:
+
+```yaml
+default_context:
+    db_storage: direct
+```
+
+`direct` is the default, so this line is optional.
+Set it explicitly to make the choice clear.
+
+## Step 2: set the data file location
+
+Point `db_filestorage_location` at the path for the `Data.fs` file.
+Lock and index files (`Data.fs.*`) are created alongside it.
+
+```yaml
+default_context:
+    db_storage: direct
+    db_filestorage_location: var/filestorage/Data.fs
+```
+
+When unset, the file defaults to a `filestorage/Data.fs` path inside the
+instance's client home.
+
+## Step 3: tune packing and safety (optional)
+
+Control how packing and database creation behave:
+
+```yaml
+default_context:
+    db_storage: direct
+    db_filestorage_location: var/filestorage/Data.fs
+
+    # Keep a .old copy of the database before packing
+    db_filestorage_pack_keep_old: true
+
+    # Skip garbage collection during packing for speed
+    db_filestorage_pack_gc: true
+
+    # Fail to start if the file is missing instead of creating it
+    db_filestorage_create: false
+```
+
+To serve a read-only replica, open the storage in read-only mode:
+
+```yaml
+default_context:
+    db_storage: direct
+    db_filestorage_read_only: true
+```
+
+## Complete example
+
+```yaml
+default_context:
+    # Serving
+    wsgi_listen: localhost:8080
+
+    initial_user_name: admin
+    initial_user_password: admin
+
+    zcml_package_includes: my.awesome.addon
+
+    # Storage
+    db_storage: direct
+    db_filestorage_location: var/filestorage/Data.fs
+```
+
+For the full set of annotated sample configurations, including the other
+backends, see {doc}`/reference/sample-configurations`.
+
+## Next steps
+
+- {doc}`/reference/database-direct` -- Full reference for all filestorage
+  options including quota, packer, and read-only settings.
+- {doc}`migrate-storage` -- Migrate data between filestorage and other
+  backends using `zodb-convert`.
+- {doc}`/explanation/storage-backends` -- Comparison of all storage backends.

--- a/docs/sources/how-to/index.md
+++ b/docs/sources/how-to/index.md
@@ -4,8 +4,13 @@
 
 Goal-oriented guides for common tasks.
 
+## Server
+
+- {doc}`set-listen-host-port`
+
 ## Database backends
 
+- {doc}`configure-filestorage`
 - {doc}`configure-relstorage`
 - {doc}`configure-pgjsonb`
 - {doc}`configure-zeo`
@@ -35,6 +40,8 @@ Goal-oriented guides for common tasks.
 ---
 hidden: true
 ---
+set-listen-host-port
+configure-filestorage
 configure-relstorage
 configure-pgjsonb
 configure-zeo

--- a/docs/sources/how-to/set-listen-host-port.md
+++ b/docs/sources/how-to/set-listen-host-port.md
@@ -1,0 +1,68 @@
+# Set the listen host and port
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to set the host and TCP port your instance listens
+on for HTTP requests.
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+
+## Step 1: set the listen address
+
+In your `instance.yaml`, set `wsgi_listen` to a `host:port` value:
+
+```yaml
+default_context:
+    wsgi_listen: localhost:8080
+```
+
+The default is `localhost:8080`, which accepts connections only from the
+local machine.
+
+To accept connections from any network interface, bind to `0.0.0.0`:
+
+```yaml
+default_context:
+    wsgi_listen: 0.0.0.0:8080
+```
+
+```{important}
+When the instance runs behind a reverse proxy, bind to `127.0.0.1` so that
+only the proxy can reach it directly:
+
+    wsgi_listen: 127.0.0.1:8080
+```
+
+## Step 2: enable a fast listen socket (optional)
+
+`wsgi_fast_listen` configures a second socket served by
+[waitress-fastlisten](https://pypi.org/project/waitress-fastlisten/).
+Install that package, then set the address:
+
+```yaml
+default_context:
+    wsgi_listen: 127.0.0.1:8080
+    wsgi_fast_listen: 127.0.0.1:8081
+```
+
+Leave `wsgi_fast_listen` empty to disable the fast socket.
+
+## Verify
+
+After generating the instance, start it and confirm the bound address in the
+startup log:
+
+```shell
+runwsgi instance/etc/zope.ini
+```
+
+The log reports the host and port Waitress serves on.
+
+## Next steps
+
+- {doc}`/reference/basic-config` -- Full reference for `wsgi_listen`,
+  `wsgi_fast_listen`, trusted proxies, and other WSGI server settings.
+- {doc}`/reference/sample-configurations` -- Complete, copy-paste
+  configurations for every backend.


### PR DESCRIPTION
Part of #46. Closes #48. Addresses the original #45 question (how to set the port).

## What
- **New** `how-to/set-listen-host-port.md` — set `wsgi_listen` / `wsgi_fast_listen`, bind to localhost vs all interfaces, and the reverse-proxy binding note. This is the how-to home the #45 question lacked.
- **New** `how-to/configure-filestorage.md` — the `direct` backend, for parity with the other backend how-tos (it previously appeared only in the first tutorial).
- Wired both into the how-to index (new "Server" group; filestorage first under "Database backends") and the toctree.

Both follow the runnable-example convention from #47 and link to `reference/sample-configurations`.

## Verification
- `sphinx-build -n` — clean, zero warnings; both pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)