### PR TITLE
Docs: operations how-tos — pack/GC and backup/restore

### DIFF
--- a/docs/sources/how-to/backup-and-restore.md
+++ b/docs/sources/how-to/backup-and-restore.md
@@ -1,0 +1,71 @@
+# Back up and restore
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to back up an instance's data and restore it.
+The right method depends on your storage backend.
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+
+## Choose an approach
+
+| Backend | Recommended backup |
+|---|---|
+| direct (filestorage) | Cold copy of `Data.fs` and the blob directory |
+| relstorage | `pg_dump` (or the database engine's native tool) |
+| pgjsonb | `pg_dump`, plus the S3 bucket when blobs are tiered |
+| zeo | Back up the storage on the ZEO server |
+| any | Portable export to a FileStorage with `zodb-convert` |
+
+## Filestorage: cold copy
+
+Stop the instance, then copy the data file and blob directory together so
+they stay consistent:
+
+```shell
+cp var/filestorage/Data.fs /backup/Data.fs
+cp -a var/blobs /backup/blobs
+```
+
+Restore by copying both back into place while the instance is stopped.
+
+```{important}
+Copy `Data.fs` and the blob directory from the same point in time.
+A blob directory that is out of sync with `Data.fs` causes
+`POSKeyError` on blob access.
+```
+
+## PostgreSQL-backed: pg_dump
+
+For RelStorage and PGJsonb, back up the underlying PostgreSQL database with
+its native tools:
+
+```shell
+pg_dump --format=custom --file=/backup/zodb.dump plone
+```
+
+Restore into an empty database:
+
+```shell
+pg_restore --dbname=plone /backup/zodb.dump
+```
+
+When PGJsonb tiers blobs to S3 (`db_pgjsonb_s3_bucket_name`), back up that
+bucket as well; the database alone does not contain the tiered blobs.
+
+## Portable backup with zodb-convert
+
+To create a storage-agnostic snapshot, export the database to a FileStorage
+with `zodb-convert`.
+This works for every backend and produces a portable `Data.fs` you can
+restore into any other backend.
+See {doc}`migrate-storage` for the step-by-step procedure using the generated
+`convert-export.conf` and `convert-import.conf` files.
+
+## Next steps
+
+- {doc}`migrate-storage` -- Move data between backends with `zodb-convert`.
+- {doc}`pack-and-gc` -- Reclaim space after restoring a large database.
+- {doc}`/explanation/blob-handling` -- How blobs are stored across backends.

--- a/docs/sources/how-to/backup-and-restore.md
+++ b/docs/sources/how-to/backup-and-restore.md
@@ -11,13 +11,28 @@ The right method depends on your storage backend.
 
 ## Choose an approach
 
-| Backend | Recommended backup |
-|---|---|
-| direct (filestorage) | Cold copy of `Data.fs` and the blob directory |
-| relstorage | `pg_dump` (or the database engine's native tool) |
-| pgjsonb | `pg_dump`, plus the S3 bucket when blobs are tiered |
-| zeo | Back up the storage on the ZEO server |
-| any | Portable export to a FileStorage with `zodb-convert` |
+A complete backup has two parts: the storage (the database or `Data.fs`) and
+any blobs kept on the filesystem.
+Whether you must back up a blob directory depends on `db_blob_mode`: in
+`shared` mode the directory holds the authoritative blobs, while in `cache`
+mode it is only a local cache and the authoritative blobs live in the
+database or on the ZEO server.
+
+| Backend | Storage backup | Filesystem blobs to back up |
+|---|---|---|
+| direct (filestorage) | Cold copy of `Data.fs` | The blob directory (always) |
+| relstorage | `pg_dump` | The shared blob directory if `db_blob_mode: shared`; none in `cache` mode (blobs are in the database) |
+| pgjsonb | `pg_dump` | None on the filesystem; the S3 bucket if blobs are tiered |
+| zeo | Back up the storage on the ZEO server | The shared blob directory if `db_blob_mode: shared` |
+| any | Portable `zodb-convert` export to a FileStorage (includes blobs) | — |
+
+```{important}
+Back up the storage and its blob directory from the same point in time.
+A blob directory that is out of sync with the storage causes `POSKeyError`
+on blob access.
+Because blob files are write-once, copying the blob directory last makes it a
+safe superset of what the storage references.
+```
 
 ## Filestorage: cold copy
 
@@ -30,12 +45,6 @@ cp -a var/blobs /backup/blobs
 ```
 
 Restore by copying both back into place while the instance is stopped.
-
-```{important}
-Copy `Data.fs` and the blob directory from the same point in time.
-A blob directory that is out of sync with `Data.fs` causes
-`POSKeyError` on blob access.
-```
 
 ## PostgreSQL-backed: pg_dump
 
@@ -52,8 +61,30 @@ Restore into an empty database:
 pg_restore --dbname=plone /backup/zodb.dump
 ```
 
+With RelStorage in the recommended `cache` mode, blobs are stored in the
+database, so `pg_dump` captures them.
 When PGJsonb tiers blobs to S3 (`db_pgjsonb_s3_bucket_name`), back up that
 bucket as well; the database alone does not contain the tiered blobs.
+
+## Shared blob directories
+
+When blobs are stored on the filesystem in `shared` mode rather than in the
+database, the blob directory (`db_blob_location`) is authoritative and needs
+its own backup.
+This applies to filestorage, to RelStorage or ZEO configured with
+`db_blob_mode: shared`, and to any setup whose blob directory is a network
+mount such as NFS.
+
+Back up the directory alongside the storage:
+
+```shell
+cp -a /srv/zodb/blobs /backup/blobs
+```
+
+For ZEO, back up the shared blob directory on whichever host exports it, in
+addition to backing up the storage on the ZEO server.
+A `cache`-mode blob directory does not need backing up: it is rebuilt from the
+authoritative storage.
 
 ## Portable backup with zodb-convert
 

--- a/docs/sources/how-to/backup-and-restore.md
+++ b/docs/sources/how-to/backup-and-restore.md
@@ -101,11 +101,17 @@ authoritative storage.
 ## Portable backup with zodb-convert
 
 To create a storage-agnostic snapshot, export the database to a FileStorage
-with `zodb-convert`.
-This works for every backend and produces a portable `Data.fs` you can
-restore into any other backend.
+and keep the resulting `Data.fs` as a portable backup you can restore into any
+backend.
+
+Use [zodb-convert](https://pypi.org/project/zodb-convert/), which works with
+every backend.
 See {doc}`migrate-storage` for the step-by-step procedure using the generated
 `convert-export.conf` and `convert-import.conf` files.
+
+With RelStorage you can instead use its bundled
+[zodbconvert](https://relstorage.readthedocs.io/en/latest/zodbconvert.html)
+command.
 
 ## Next steps
 

--- a/docs/sources/how-to/backup-and-restore.md
+++ b/docs/sources/how-to/backup-and-restore.md
@@ -66,6 +66,19 @@ database, so `pg_dump` captures them.
 When PGJsonb tiers blobs to S3 (`db_pgjsonb_s3_bucket_name`), back up that
 bucket as well; the database alone does not contain the tiered blobs.
 
+## ZEO
+
+A ZEO client holds no authoritative data of its own, so there is nothing to
+back up on the client.
+Back up on the ZEO server host instead: the server runs its own storage --
+usually a FileStorage or RelStorage -- so use the matching method above
+(cold copy of `Data.fs`, or `pg_dump`) against that storage.
+
+If the deployment uses a shared blob directory, also back it up as described
+below.
+ZEO server administration is otherwise outside the scope of this template;
+consult the ZODB/ZEO documentation.
+
 ## Shared blob directories
 
 When blobs are stored on the filesystem in `shared` mode rather than in the

--- a/docs/sources/how-to/backup-and-restore.md
+++ b/docs/sources/how-to/backup-and-restore.md
@@ -70,9 +70,8 @@ bucket as well; the database alone does not contain the tiered blobs.
 
 A ZEO client holds no authoritative data of its own, so there is nothing to
 back up on the client.
-Back up on the ZEO server host instead: the server runs its own storage --
-usually a FileStorage or RelStorage -- so use the matching method above
-(cold copy of `Data.fs`, or `pg_dump`) against that storage.
+Back up on the ZEO server host instead: the server runs a FileStorage, so use
+the cold-copy method above against the server's `Data.fs`.
 
 If the deployment uses a shared blob directory, also back it up as described
 below.

--- a/docs/sources/how-to/index.md
+++ b/docs/sources/how-to/index.md
@@ -26,6 +26,8 @@ Goal-oriented guides for common tasks.
 ## Operations
 
 - {doc}`use-environment-variables`
+- {doc}`pack-and-gc`
+- {doc}`backup-and-restore`
 
 ## Upgrading
 
@@ -43,5 +45,7 @@ migrate-storage
 configure-cors
 configure-logging
 use-environment-variables
+pack-and-gc
+backup-and-restore
 upgrade-v1-to-v2
 ```

--- a/docs/sources/how-to/pack-and-gc.md
+++ b/docs/sources/how-to/pack-and-gc.md
@@ -1,0 +1,75 @@
+# Pack and garbage-collect the database
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to pack the ZODB to reclaim disk space and remove
+unreferenced objects (garbage collection).
+The procedure depends on your storage backend.
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+- A generated instance with data to pack.
+
+## RelStorage
+
+For RelStorage, the cookiecutter always generates `etc/relstorage-pack.conf`
+for the `zodbpack` command-line utility.
+Run it from your instance directory:
+
+```shell
+zodbpack etc/relstorage-pack.conf
+```
+
+`zodbpack` packs the database and performs garbage collection.
+For all options, read
+[Packing or reference checking a ZODB storage](https://relstorage.readthedocs.io/en/latest/zodbpack.html).
+
+Schedule regular packing with cron, for example weekly:
+
+```text
+0 3 * * 0  cd /srv/instance && zodbpack etc/relstorage-pack.conf
+```
+
+## Filestorage
+
+For the `direct` backend, pack from the Zope Management Interface:
+open {menuselection}`Control_Panel --> Database Management --> main`, set the
+number of days of history to keep, and select {guilabel}`Pack`.
+
+Two settings control packing behavior:
+
+```yaml
+default_context:
+    db_storage: direct
+
+    # Keep a .old copy of the database before packing
+    db_filestorage_pack_keep_old: true
+
+    # Skip garbage collection during packing for speed
+    db_filestorage_pack_gc: true
+```
+
+See {doc}`/reference/database-direct` for details.
+
+## PGJsonb
+
+A history-free PGJsonb database (the default) does not accumulate undo
+history, so routine packing is rarely needed.
+
+A history-preserving database (`db_pgjsonb_history_preserving: true`) grows
+over time and requires regular packing through the storage's own tooling.
+See {doc}`/reference/database-pgjsonb`.
+
+## ZEO
+
+Packing a ZEO database is a server-side operation: pack the storage on the
+ZEO server, not from the client.
+ZEO server administration is outside the scope of this template; consult the
+ZODB/ZEO documentation.
+
+## Next steps
+
+- {doc}`/reference/database-relstorage` -- RelStorage command-line utilities.
+- {doc}`backup-and-restore` -- Back up before packing large databases.
+- {doc}`/explanation/storage-backends` -- Comparison of all storage backends.


### PR DESCRIPTION
Part of #46. Closes #49.

## What
- **New** `how-to/pack-and-gc.md` — packing and garbage collection per backend: `zodbpack etc/relstorage-pack.conf` (RelStorage), ZMI pack for filestorage, notes for PGJsonb history modes, and server-side packing for ZEO.
- **New** `how-to/backup-and-restore.md` — cold copy for filestorage, `pg_dump`/`pg_restore` for the PostgreSQL-backed stores (plus the S3 bucket when PGJsonb tiers blobs), and a portable `zodb-convert` export that cross-links `migrate-storage`.
- Grouped both under "Operations" in the how-to index and toctree.

## Accuracy
Every command is limited to tooling the template actually generates (`relstorage-pack.conf`, `convert-*.conf`) or standard utilities (`zodbpack`, `pg_dump`, ZMI pack). No fabricated cookiecutter-specific commands.

## Verification
- `sphinx-build -n` — clean, zero warnings; both pages render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)