### PR TITLE
Docs: production how-tos — reverse proxy and debug/profiling

### DIFF
--- a/docs/sources/how-to/enable-debug-profiling.md
+++ b/docs/sources/how-to/enable-debug-profiling.md
@@ -1,0 +1,70 @@
+# Enable debug mode and profiling
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to turn on debug mode and request profiling for
+local development.
+
+```{warning}
+These settings are for development only.
+Never enable debug mode, exception propagation, or profiling in production.
+```
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+
+## Step 1: enable debug mode
+
+Turn on debug mode and verbose security in your `instance.yaml`:
+
+```yaml
+default_context:
+    debug_mode: true
+    verbose_security: true
+```
+
+To let exceptions propagate into the WSGI pipeline so debugging middleware
+can handle them, also set `debug_exceptions`:
+
+```yaml
+default_context:
+    debug_mode: true
+    verbose_security: true
+    debug_exceptions: true
+```
+
+## Step 2: enable profiling
+
+Profiling uses [repoze.profile](https://repozeprofile.readthedocs.io/).
+Install it first:
+
+```shell
+pip install repoze.profile
+```
+
+Then enable it and choose the through-the-web path for inspecting the last
+profiled request:
+
+```yaml
+default_context:
+    profile_repoze: true
+    profile_repoze_path: /__profile__
+```
+
+## Step 3: inspect the results
+
+Start the instance, make a few requests, then open the profile path in your
+browser to see the most recent profiled request:
+
+```text
+http://localhost:8080/__profile__
+```
+
+The raw profile data is also written to `profile_repoze_log_filename` for
+offline analysis.
+
+## Next steps
+
+- {doc}`/reference/development` -- Full reference for debug, verbose security,
+  and `repoze.profile` settings.

--- a/docs/sources/how-to/index.md
+++ b/docs/sources/how-to/index.md
@@ -23,6 +23,14 @@ Goal-oriented guides for common tasks.
 
 - {doc}`configure-logging`
 
+## Production
+
+- {doc}`run-behind-reverse-proxy`
+
+## Development
+
+- {doc}`enable-debug-profiling`
+
 ## Operations
 
 - {doc}`use-environment-variables`
@@ -41,6 +49,8 @@ configure-zeo
 configure-z3blobs
 migrate-storage
 configure-cors
+run-behind-reverse-proxy
+enable-debug-profiling
 configure-logging
 use-environment-variables
 upgrade-v1-to-v2

--- a/docs/sources/how-to/run-behind-reverse-proxy.md
+++ b/docs/sources/how-to/run-behind-reverse-proxy.md
@@ -1,0 +1,70 @@
+# Run behind a reverse proxy
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to run an instance behind a reverse proxy such as
+nginx or Apache, so the proxy terminates TLS and forwards requests to Zope.
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+- A reverse proxy (nginx, Apache, or similar) in front of the instance.
+
+## Step 1: bind to localhost
+
+Set `wsgi_listen` to `127.0.0.1` so only the proxy on the same host can reach
+the instance directly:
+
+```yaml
+default_context:
+    wsgi_listen: 127.0.0.1:8080
+```
+
+## Step 2: declare the trusted proxy
+
+List the proxy's address in `trusted_proxy` so Zope honors the forwarded
+headers it sends:
+
+```yaml
+default_context:
+    wsgi_listen: 127.0.0.1:8080
+    trusted_proxy: "127.0.0.1"
+```
+
+`trusted_proxy` accepts a comma-separated list of IP addresses or hostnames.
+
+## Step 3: clear untrusted proxy headers
+
+Tell Waitress to strip forwarded headers that do not come from a trusted
+proxy, so clients cannot spoof them:
+
+```yaml
+default_context:
+    wsgi_listen: 127.0.0.1:8080
+    trusted_proxy: "127.0.0.1"
+    wsgi_clear_untrusted_proxy_headers: true
+```
+
+## Step 4: configure the proxy
+
+Forward requests to the instance and pass the original host and scheme.
+Use Zope virtual host rewriting so generated URLs match the public address.
+A representative nginx location block:
+
+```nginx
+location / {
+    proxy_pass http://127.0.0.1:8080/VirtualHostBase/https/$host:443/Plone/VirtualHostRoot/;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+```
+
+Replace `Plone` with the id of your Zope object (for example, the Plone site)
+and adjust the scheme and port to match your deployment.
+
+## Next steps
+
+- {doc}`/reference/basic-config` -- Reference for `wsgi_listen`,
+  `trusted_proxy`, and `wsgi_clear_untrusted_proxy_headers`.
+- {doc}`configure-cors` -- Configure CORS when the API is served cross-origin.


### PR DESCRIPTION
Part of #46. Closes #50.

## What
- **New** `how-to/run-behind-reverse-proxy.md` — bind to `127.0.0.1`, declare `trusted_proxy`, set `wsgi_clear_untrusted_proxy_headers`, and a representative nginx virtual-host block. Keeps ZEO/server infra out of scope.
- **New** `how-to/enable-debug-profiling.md` — `debug_mode`, `verbose_security`, `debug_exceptions`, and `repoze.profile` setup, with a clear "development only" warning.
- Added "Production" and "Development" groups to the how-to index and toctree.

## Verification
- `sphinx-build -n` — clean, zero warnings; both pages render.

> Note: the how-to index toctree edits sit in a different region than #54/#55, so they should merge cleanly; a trivial toctree merge is possible if ordering shifts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)