### PR TITLE
Docs: configuration-workflow explanation + slim docker tutorial + dedupe INSTANCE_*

### DIFF
--- a/docs/sources/explanation/configuration-workflow.md
+++ b/docs/sources/explanation/configuration-workflow.md
@@ -1,0 +1,76 @@
+# The configuration workflow
+
+<!-- diataxis: explanation -->
+
+This page explains how a configuration travels from a small YAML file to a
+running instance, and why the containerized workflow is shaped the way it is.
+
+## From YAML to instance
+
+The template is driven by a single `instance.yaml` file.
+Its `default_context` section maps directly to the template variables, and
+`cookiecutter` renders those variables into the concrete `zope.conf`,
+`zope.ini`, and `site.zcml` files that Zope reads at startup.
+
+This indirection is deliberate.
+You describe *intent* in a compact, reviewable file, and the template expands
+it into the verbose, interdependent configuration files that Zope expects.
+Changing one value in the YAML and re-rendering is safer than hand-editing
+several generated files and keeping them consistent.
+
+## Why a transform layer
+
+Baking configuration into a container image is convenient but wrong for
+anything that varies between environments or must stay secret.
+Database hostnames, credentials, and listen addresses differ between staging
+and production, and secrets must never be committed to an image.
+
+The `transform_from_environment.py` helper bridges this gap.
+It reads the base `instance.yaml`, merges every `INSTANCE_*` environment
+variable on top of it, and writes an effective configuration that
+`cookiecutter` then renders.
+The base file carries the stable defaults; the environment carries the
+per-deployment and secret values.
+
+## The naming conventions
+
+Each environment variable named `INSTANCE_<key>` sets `<key>` in
+`default_context`.
+The prefix is stripped, and the remainder becomes the configuration key.
+Setting a variable to an empty string clears that key, which is how a feature
+is disabled in production -- for example, clearing a development password so
+that a fresh one is generated.
+
+Some template variables are dictionaries rather than scalars.
+The `_DICT_` infix addresses a single entry inside such a dictionary, so
+`INSTANCE_environment_DICT_TZ=Europe/Berlin` sets the `TZ` entry of the
+`environment` dictionary without replacing the whole mapping.
+
+## Why generate at container start
+
+The transform and `cookiecutter` run in the container *entrypoint*, on every
+start, not at image build time.
+This is the crucial design choice for containerized deployments.
+
+Build time is too early.
+The `INSTANCE_*` variables that carry secrets and per-deployment values only
+exist at runtime, injected by the orchestrator.
+Rendering the configuration at startup is what lets one image serve every
+environment.
+
+## Why pin and vendor the template
+
+The image downloads a pinned version of the template and the transform helper
+at build time, then runs entirely from those local files at startup.
+
+Pinning a specific version makes builds reproducible: the same image always
+renders the same configuration.
+Vendoring the template into the image means the entrypoint needs no network
+access at startup, which removes a class of runtime failures and shrinks the
+container's attack surface.
+
+## See also
+
+- {doc}`/how-to/use-environment-variables` -- The task-oriented procedure.
+- {doc}`/tutorials/docker-deployment` -- The same workflow applied end-to-end.
+- {doc}`/reference/helpers` -- Reference for the helper scripts.

--- a/docs/sources/explanation/index.md
+++ b/docs/sources/explanation/index.md
@@ -10,5 +10,6 @@ hidden: true
 ---
 storage-backends
 blob-handling
+configuration-workflow
 why-cookiecutter
 ```

--- a/docs/sources/how-to/use-environment-variables.md
+++ b/docs/sources/how-to/use-environment-variables.md
@@ -41,21 +41,18 @@ picked up by the transform script. The prefix is stripped and the remaining
 name becomes the configuration key:
 
 ```bash
-export INSTANCE_wsgi_fast_listen=
+# Override scalars; the INSTANCE_ prefix is stripped to form the key
 export INSTANCE_wsgi_listen=127.0.0.1:8080
-export INSTANCE_initial_user_password=
-export INSTANCE_debug_mode=false
-export INSTANCE_verbose_security=false
 export INSTANCE_db_storage=relstorage
-export INSTANCE_db_blob_mode=cache
-export INSTANCE_db_relstorage_keep_history=false
-export INSTANCE_db_relstorage=postgresql
 export INSTANCE_db_relstorage_postgresql_dsn="host='db' dbname='plone' user='plone' password='verysecret'"
-export INSTANCE_db_cache_size=50000
-export INSTANCE_db_cache_size_bytes=1500MB
+
+# An empty value clears a key (here, generate a fresh password)
+export INSTANCE_initial_user_password=
 ```
 
-Setting a variable to an empty string effectively clears that value.
+Setting a variable to an empty string clears that value.
+For a complete production set applied end-to-end, see
+{doc}`/tutorials/docker-deployment`.
 
 ## Step 4: run the transform script
 
@@ -83,16 +80,19 @@ export INSTANCE_environment_DICT_PTS_LANGUAGES="de en"
 export INSTANCE_environment_DICT_zope_i18n_allowed_languages="de en"
 ```
 
+See {doc}`/explanation/configuration-workflow` for how the `_DICT_` infix
+works.
+
 ## Docker integration pattern
 
-See the {doc}`/tutorials/docker-deployment` tutorial for a complete example.
-The key points:
-
-- **Pin the template version** at build time (download the zip archive).
-- **Run the transform + cookiecutter in an entrypoint**, not at build time,
-  so that `INSTANCE_*` environment variables (secrets, DSNs) are available.
-- **No network at runtime** -- the entrypoint uses only local files.
+For why the transform runs in the container entrypoint, why the template
+version is pinned, and how the entrypoint needs no network access at runtime,
+see {doc}`/explanation/configuration-workflow`.
+The {doc}`/tutorials/docker-deployment` tutorial applies the whole pattern
+end-to-end.
 
 ## Next steps
 
+- {doc}`/explanation/configuration-workflow` -- Why this workflow is shaped
+  the way it is.
 - {doc}`/reference/helpers` -- Reference documentation for helper scripts.

--- a/docs/sources/tutorials/docker-deployment.md
+++ b/docs/sources/tutorials/docker-deployment.md
@@ -162,12 +162,11 @@ else
 fi
 ```
 
-Key design choices:
-
-- The template zip and helper script are **downloaded at build time** and pinned
-  to a specific version -- no network access at container startup (stability +
-  security).
-- The entrypoint only runs the transform and cookiecutter against local files.
+The template and helper are downloaded and pinned at build time, and the
+entrypoint runs only against local files, so no network access is needed at
+startup.
+For the reasoning behind generating at startup and pinning the version, see
+{doc}`/explanation/configuration-workflow`.
 
 Now start the container with runtime environment variables:
 
@@ -192,23 +191,17 @@ services:
       - "8080:8080"
 ```
 
-## Advanced: dict values with `_DICT_`
+## Set dictionary values
 
-Some template variables are dictionaries. The transform script supports a
-special `_DICT_` infix to set individual keys inside a dict:
+Some template variables are dictionaries.
+Use the `_DICT_` infix to set a single entry inside one:
 
 ```bash
-export INSTANCE_environment_DICT_zope_i18n_compile_mo_files=true
 export INSTANCE_environment_DICT_TZ=Europe/Berlin
 ```
 
-This results in:
-
-```yaml
-environment:
-    zope_i18n_compile_mo_files: 'true'
-    TZ: 'Europe/Berlin'
-```
+See {doc}`/explanation/configuration-workflow` for how the `_DICT_` infix
+works.
 
 ## What you learned
 


### PR DESCRIPTION
Part of #46. Closes #51.

## What
- **New** `explanation/configuration-workflow.md` — the conceptual owner of the cookiecutter → transform → entrypoint workflow: why a transform layer, the `INSTANCE_`/`_DICT_` conventions, why generate at container start, why pin and vendor the template.
- **Slim** `tutorials/docker-deployment.md` — moved the "key design choices" rationale and the `_DICT_` mechanics into the explanation and linked to it; the tutorial keeps its concrete steps.
- **Dedupe** the near-identical `INSTANCE_*` block: the how-to (`use-environment-variables`) now shows a short illustrative example and links the tutorial for the full applied set; the tutorial keeps the canonical end-to-end block. The how-to has no merged-output step, so trimming it needs no cascade.

## Verification
- `sphinx-build -n` — clean, zero warnings; new page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)