### PR TITLE
Docs: journey polish — lifecycle index, glossary, product_config, consistent indexes

### DIFF
--- a/docs/sources/explanation/index.md
+++ b/docs/sources/explanation/index.md
@@ -4,6 +4,14 @@
 
 Background knowledge and design decisions.
 
+- {doc}`storage-backends` -- Comparison of the storage backends and their
+  trade-offs.
+- {doc}`blob-handling` -- How blobs are stored and cached across backends.
+- {doc}`configuration-workflow` -- How a YAML file becomes a running instance,
+  and why the containerized workflow is shaped the way it is.
+- {doc}`why-cookiecutter` -- Why this project generates configuration with a
+  cookiecutter template.
+
 ```{toctree}
 ---
 hidden: true

--- a/docs/sources/glossary.md
+++ b/docs/sources/glossary.md
@@ -1,0 +1,34 @@
+# Glossary
+
+```{glossary}
+blob
+    Binary large object.
+    A large binary value, such as an uploaded file or image, stored outside
+    the pickled object state -- either on the filesystem or in the storage
+    backend.
+    See {doc}`/explanation/blob-handling`.
+
+FileStorage
+    The default ZODB storage.
+    A single process keeps all object data in one `Data.fs` file, with blobs
+    in an adjacent directory.
+    Configured with `db_storage: direct`.
+
+PGJsonb
+    A ZODB storage backend that keeps object state as PostgreSQL JSONB,
+    making it queryable with SQL.
+    Provided by [zodb-pgjsonb](https://pypi.org/project/zodb-pgjsonb/).
+
+RelStorage
+    A ZODB storage backend that stores pickled object state in a relational
+    database such as PostgreSQL, letting many clients share one database.
+
+ZEO
+    Zope Enterprise Objects.
+    A client-server ZODB storage that lets multiple Zope processes share a
+    single database over the network.
+
+ZODB
+    The Zope Object Database, the transactional object store in which Zope and
+    Plone persist their content.
+```

--- a/docs/sources/how-to/index.md
+++ b/docs/sources/how-to/index.md
@@ -4,11 +4,17 @@
 
 Goal-oriented guides for common tasks.
 
-## Server
+These guides follow the life of an instance, from first configuration through
+production deployment to day-to-day operations.
+Choose a storage backend such as {term}`FileStorage`, {term}`RelStorage`,
+{term}`ZEO`, or {term}`PGJsonb`, then deploy and operate it.
+New to the template? Start with the {doc}`/tutorials/index`.
+
+## Set up the server
 
 - {doc}`set-listen-host-port`
 
-## Database backends
+## Choose a storage backend
 
 - {doc}`configure-filestorage`
 - {doc}`configure-relstorage`
@@ -16,33 +22,28 @@ Goal-oriented guides for common tasks.
 - {doc}`configure-zeo`
 - {doc}`configure-z3blobs`
 
-## Storage migration
-
-- {doc}`migrate-storage`
-
-## Web layer
+## Configure the application
 
 - {doc}`configure-cors`
-
-## Logging
-
 - {doc}`configure-logging`
+- {doc}`set-product-config`
 
-## Production
+## Deploy to production
 
 - {doc}`run-behind-reverse-proxy`
+- {doc}`use-environment-variables`
 
-## Development
+## Develop and debug
 
 - {doc}`enable-debug-profiling`
 
-## Operations
+## Operate
 
-- {doc}`use-environment-variables`
 - {doc}`pack-and-gc`
 - {doc}`backup-and-restore`
+- {doc}`migrate-storage`
 
-## Upgrading
+## Upgrade
 
 - {doc}`upgrade-v1-to-v2`
 
@@ -56,13 +57,14 @@ configure-relstorage
 configure-pgjsonb
 configure-zeo
 configure-z3blobs
-migrate-storage
 configure-cors
-run-behind-reverse-proxy
-enable-debug-profiling
 configure-logging
+set-product-config
+run-behind-reverse-proxy
 use-environment-variables
+enable-debug-profiling
 pack-and-gc
 backup-and-restore
+migrate-storage
 upgrade-v1-to-v2
 ```

--- a/docs/sources/how-to/set-product-config.md
+++ b/docs/sources/how-to/set-product-config.md
@@ -1,0 +1,42 @@
+# Set add-on product configuration
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to provide Zope `<product-config>` sections that
+add-ons read for their own configuration.
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+
+## Step 1: define the configuration
+
+Set `product_config` in your `instance.yaml` to a dictionary of dictionaries.
+Each top-level key becomes a section name, and its dictionary provides that
+section's key/value pairs:
+
+```yaml
+default_context:
+    product_config:
+        my_addon:
+            setting1: value1
+            setting2: value2
+```
+
+## Step 2: check the generated output
+
+This renders a `<product-config>` section in `zope.conf`:
+
+```text
+<product-config my_addon>
+    setting1 value1
+    setting2 value2
+</product-config>
+```
+
+The add-on reads these values through the Zope configuration API.
+
+## Next steps
+
+- {doc}`/reference/basic-config` -- Reference for `product_config` and the
+  other core settings.

--- a/docs/sources/index.md
+++ b/docs/sources/index.md
@@ -80,4 +80,5 @@ tutorials/index
 how-to/index
 reference/index
 explanation/index
+glossary
 ```

--- a/docs/sources/reference/index.md
+++ b/docs/sources/reference/index.md
@@ -4,9 +4,35 @@
 
 Complete configuration reference for all cookiecutter-zope-instance variables.
 
+## Server and application
+
+- {doc}`basic-config`
+- {doc}`sample-configurations`
+- {doc}`base-locations`
+- {doc}`initial-user`
+- {doc}`zcml`
+- {doc}`logging`
+- {doc}`cors`
+- {doc}`development`
+
+## Database
+
+- {doc}`database-common`
+- {doc}`database-blobs`
+- {doc}`database-direct`
+- {doc}`database-relstorage`
+- {doc}`database-zeo`
+- {doc}`database-pgjsonb`
+- {doc}`database-z3blobs`
+
+## Helpers and meta
+
+- {doc}`helpers`
+- {doc}`changelog`
+
 ```{toctree}
 ---
-maxdepth: 2
+hidden: true
 ---
 base-locations
 basic-config


### PR DESCRIPTION
Part of #46. Closes #52. Final pass of the documentation plan.

## What
- **Lifecycle how-to index** — regrouped `how-to/index.md` as a journey: set up the server → choose a storage backend → configure the application → deploy to production → develop and debug → operate → upgrade. Added a `{term}`-linked lead-in.
- **Glossary** — new `glossary.md` (blob, FileStorage, PGJsonb, RelStorage, ZEO, ZODB), wired into the root toctree and referenced from the how-to index.
- **`product_config` how-to** — new `how-to/set-product-config.md` for Zope `<product-config>` sections.
- **Consistent section indexes** — gave the explanation index a visible list, and converted the reference index from a visible raw toctree to grouped lists + hidden toctree, matching the how-to index. (The reference index was the only section rendering a raw toctree.)

## Verification
- `sphinx-build -n` — clean, zero warnings; glossary `{term}` links resolve; new page renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)