### PR TITLE
Docs: remove bogus PyPI link, refresh llms.txt

### DIFF
--- a/docs/sources/conf.py
+++ b/docs/sources/conf.py
@@ -44,10 +44,6 @@ html_theme_options = {
             "title": "GitHub",
             "url": "https://github.com/plone/cookiecutter-zope-instance",
         },
-        {
-            "title": "PyPI",
-            "url": "https://pypi.org/project/cookiecutter-zope-instance/",
-        },
     ],
 }
 

--- a/docs/sources/llms.txt
+++ b/docs/sources/llms.txt
@@ -13,7 +13,7 @@ configuration file.
 - License: GPL-2.0
 - Python: 3.10+
 - Repository: https://github.com/plone/cookiecutter-zope-instance
-- PyPI: https://pypi.org/project/cookiecutter-zope-instance/
+- Install: used directly from GitHub via `cookiecutter gh:plone/cookiecutter-zope-instance` (not published on PyPI)
 
 ## Features
 
@@ -103,6 +103,7 @@ separator for nested dict values.
 ## Documentation Sections
 
 - [Tutorials](tutorials/index.md): First instance, Docker deployment
-- [How-To Guides](how-to/index.md): RelStorage, PGJsonb, ZEO, z3blobs, CORS, env vars, upgrading
-- [Reference](reference/index.md): All configuration variables documented
-- [Explanation](explanation/index.md): Storage backends, blob handling, rationale
+- [How-To Guides](how-to/index.md): set the listen host/port, configure a storage backend (filestorage, RelStorage, PGJsonb, ZEO, z3blobs), configure the application (CORS, logging, product-config), deploy to production (reverse proxy, environment variables), enable debug/profiling, operate (pack/GC, backup/restore, migrate storage), upgrade
+- [Reference](reference/index.md): All configuration variables, plus sample configurations
+- [Explanation](explanation/index.md): Storage backends, blob handling, configuration workflow, rationale
+- [Glossary](glossary.md): Key terms (blob, FileStorage, RelStorage, ZEO, PGJsonb, ZODB)


### PR DESCRIPTION
cookiecutter-zope-instance is a GitHub cookiecutter template (used via `cookiecutter gh:plone/cookiecutter-zope-instance`), not a PyPI package — but two places linked it to PyPI.

## What
- Remove the **PyPI** nav link from the theme (`conf.py`).
- Remove the `PyPI:` line from `llms.txt`, replacing it with an install note clarifying it is used from GitHub, not PyPI.
- Refresh `llms.txt` "Documentation Sections" so it reflects the current state: the how-to lifecycle, `sample-configurations` in reference, the `configuration-workflow` explanation, and the new glossary.

(The other `pypi.org/project/...` links in the docs point to genuinely published packages — zodb-convert, zodb-pgjsonb, etc. — and are left as-is.)

## Verification
- `sphinx-build -n` — clean, zero warnings; no residual `pypi.org/project/cookiecutter-zope` references remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)