### PR TITLE
feat: generic wsgi_filters pipeline hook

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.0.3 (unreleased)
+## 3.1.0 (unreleased)
 
 - Feature: Generic `wsgi_filters` option to inject arbitrary WSGI/PasteDeploy
   filters into the pipeline (e.g. `plone.observability`). Each filter has a

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,12 @@
 
 ## 3.0.3 (unreleased)
 
-- No changes yet.
+- Feature: Generic `wsgi_filters` option to inject arbitrary WSGI/PasteDeploy
+  filters into the pipeline (e.g. `plone.observability`). Each filter has a
+  `use`, optional `options`, and optional `position` (`outer`/`inner`). The
+  built-in `profile` and `translogger` filters now render through the same
+  unified pipeline path.
+  [@jensens]
 
 ## 3.0.2 (2026-04-03)
 

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -32,6 +32,7 @@
   "wsgi_channel_timeout": "",
   "wsgi_clear_untrusted_proxy_headers": false,
   "wsgi_app_entrypoint": "egg:Zope#main",
+  "wsgi_filters": {},
 
   "environment": {
     "zope_i18n_compile_mo_files": "true",

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -1,5 +1,5 @@
 {
-  "_version": "3.0.3.dev0",
+  "_version": "3.1.0.dev0",
   "_extensions": ["local_extensions.ZopeExtensions"],
   "target": "instance",
   "location_clienthome": "{{ cookiecutter.target }}/var",

--- a/docs/sources/how-to/add-wsgi-middleware.md
+++ b/docs/sources/how-to/add-wsgi-middleware.md
@@ -1,0 +1,65 @@
+# Add WSGI middleware to the pipeline
+
+<!-- diataxis: how-to -->
+
+This guide shows you how to inject WSGI/PasteDeploy filters into the generated
+`zope.ini` pipeline -- for example the request-metrics and OpenTelemetry
+middleware from [plone.observability](https://github.com/plone/plone.observability).
+
+## Prerequisites
+
+- New to this template? Start with {doc}`/tutorials/first-zope-instance`.
+- The middleware package must be installed and expose a
+  `paste.filter_app_factory` entry point.
+
+## Step 1: define the filters
+
+Set `wsgi_filters` in your `instance.yaml` to a dictionary. Each key is the
+filter name; its value configures that filter:
+
+```yaml
+default_context:
+    wsgi_filters:
+        observability:
+            use: "egg:plone.observability#observability"
+        opentelemetry:
+            use: "egg:plone.observability#opentelemetry"
+```
+
+Each entry's value supports these fields:
+
+- `use` (required) -- the PasteDeploy entry point of the filter.
+- `options` (optional) -- a mapping of additional `key: value` lines rendered
+  verbatim into the `[filter:<name>]` section.
+- `position` (optional) -- `outer` (the default) places the filter ahead of the
+  built-in `profile`/`translogger` filters, so it wraps the whole request;
+  `inner` places it closest to the application, just before
+  `egg:Zope#httpexceptions`.
+
+Reserved names that cannot be used: `zope`, `profile`, `translogger`,
+`httpexceptions`, `main`.
+
+## Step 2: check the generated output
+
+This renders one `[filter:<name>]` section per entry, wired into
+`[pipeline:main]`:
+
+```ini
+[pipeline:main]
+pipeline =
+    observability
+    opentelemetry
+    egg:Zope#httpexceptions
+    zope
+
+[filter:observability]
+use = egg:plone.observability#observability
+
+[filter:opentelemetry]
+use = egg:plone.observability#opentelemetry
+```
+
+## Next steps
+
+- {doc}`/reference/basic-config` -- Reference for `wsgi_filters` and the other
+  core settings.

--- a/docs/sources/how-to/index.md
+++ b/docs/sources/how-to/index.md
@@ -27,6 +27,7 @@ New to the template? Start with the {doc}`/tutorials/index`.
 - {doc}`configure-cors`
 - {doc}`configure-logging`
 - {doc}`set-product-config`
+- {doc}`add-wsgi-middleware`
 
 ## Deploy to production
 
@@ -60,6 +61,7 @@ configure-z3blobs
 configure-cors
 configure-logging
 set-product-config
+add-wsgi-middleware
 run-behind-reverse-proxy
 use-environment-variables
 enable-debug-profiling

--- a/docs/sources/reference/basic-config.md
+++ b/docs/sources/reference/basic-config.md
@@ -16,6 +16,7 @@ Core WSGI server, environment, and request-handling settings.
 | `wsgi_clear_untrusted_proxy_headers` | `false` | `true`, `false` |
 | `wsgi_channel_timeout` | *(unset, default `120`)* | integer (seconds) |
 | `wsgi_app_entrypoint` | `egg:Zope#main` | entrypoint |
+| `wsgi_filters` | `{}` (empty dict) | mapping `name → {use, options?, position?}` |
 | `trusted_proxy` | *(unset)* | comma-separated IPs/hostnames |
 
 **`wsgi_fast_listen`** -- Like `wsgi_listen`, but uses [waitress_fastlisten](https://pypi.org/project/waitress-fastlisten/). Needs the latter package to be installed (add it to *requirements.txt*).
@@ -23,6 +24,8 @@ Core WSGI server, environment, and request-handling settings.
 **`wsgi_clear_untrusted_proxy_headers`** -- Tells Waitress (WSGI server) to remove any untrusted proxy headers (`Forwarded`, `X-Forwarded-For`, `X-Forwarded-By`, `X-Forwarded-Host`, `X-Forwarded-Port`, `X-Forwarded-Proto`) not explicitly allowed by `trusted_proxy_headers`.
 
 **`wsgi_channel_timeout`** -- Maximum time in seconds to receive a complete request from a client. If the client does not send a complete request within this time, the connection is closed. Default is 120 seconds.
+
+**`wsgi_filters`** -- A mapping of WSGI/PasteDeploy filters to inject into the pipeline. Each key is the filter name and renders a `[filter:<name>]` section wired into `[pipeline:main]`. Each value supports `use` (required, the PasteDeploy entry point), `options` (optional mapping of additional `key = value` lines rendered verbatim into the filter section), and `position` (`outer`, the default — placed ahead of the built-in `profile`/`translogger` filters so it wraps the whole request; or `inner` — placed closest to the application, just before `egg:Zope#httpexceptions`). Reserved names that cannot be used: `zope`, `profile`, `translogger`, `httpexceptions`, `main`. See {doc}`/how-to/add-wsgi-middleware`.
 
 **`trusted_proxy`** -- A comma-separated list of IP addresses or hostnames of trusted reverse proxies. When set, Zope will trust proxy-related headers (such as `X-Forwarded-For`) from these sources. Each value becomes a separate `trusted-proxy` directive in `zope.conf`. Example: `"10.0.0.1,10.0.0.2"`.
 

--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -123,3 +123,23 @@ elif upgrade_warnings:
     for warning_msg in upgrade_warnings:
         print(f" - Warning: {warning_msg}")
     print()
+
+# wsgi_filters validation
+RESERVED_FILTERS = {"zope", "profile", "translogger", "httpexceptions", "main"}
+VALID_POSITIONS = {"outer", "inner"}
+
+wsgi_filters = {{ cookiecutter.wsgi_filters }}
+for name, _f in wsgi_filters.items():
+    if name in RESERVED_FILTERS:
+        print(f"Error: wsgi_filter name '{name}' is reserved!")
+        exit(1)
+    if not isinstance(_f, dict):
+        print(f"Error: wsgi_filter '{name}' must be a mapping, got {_f!r}!")
+        exit(1)
+    if not _f.get("use"):
+        print(f"Error: wsgi_filter '{name}' is missing required 'use'!")
+        exit(1)
+    position = _f.get("position", "outer")
+    if position not in VALID_POSITIONS:
+        print(f"Error: wsgi_filter '{name}' has invalid position '{position}' (outer|inner)!")
+        exit(1)

--- a/tests/test_bake_wsgi_filters.py
+++ b/tests/test_bake_wsgi_filters.py
@@ -1,0 +1,74 @@
+from utils import bake_in_temp_dir
+
+
+def _pipeline_block(zope_ini):
+    """Return the lines of the [pipeline:main] pipeline = ... block."""
+    lines = zope_ini.split("\n")
+    out = []
+    in_block = False
+    for line in lines:
+        if line.strip() == "[pipeline:main]":
+            in_block = True
+            continue
+        if in_block:
+            if line.startswith("[") and line.strip() != "pipeline =":
+                break
+            out.append(line)
+    return "\n".join(out)
+
+
+def test_generic_outer_filter_in_pipeline_and_block(cookies):
+    """A user filter (default position=outer) appears before httpexceptions and gets a filter block."""
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={
+            "wsgi_filters": {
+                "observability": {"use": "egg:plone.observability#observability"},
+            },
+        },
+    ) as result:
+        assert result.exit_code == 0
+        zope_ini = (result.project_path / "etc" / "zope.ini").read_text()
+        pipeline = _pipeline_block(zope_ini)
+        # appears in the pipeline, before the fixed httpexceptions entry
+        assert "observability" in pipeline
+        assert pipeline.index("observability") < pipeline.index("egg:Zope#httpexceptions")
+        # outer => before built-in translogger (access_log default on)
+        assert pipeline.index("observability") < pipeline.index("translogger")
+        # filter block exists
+        assert "[filter:observability]" in zope_ini
+        assert "use = egg:plone.observability#observability" in zope_ini
+
+
+def test_generic_inner_filter_after_translogger(cookies):
+    """position=inner puts the filter after translogger, right before httpexceptions."""
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={
+            "wsgi_filters": {
+                "dbg": {"use": "egg:foo#bar", "position": "inner"},
+            },
+        },
+    ) as result:
+        assert result.exit_code == 0
+        pipeline = _pipeline_block((result.project_path / "etc" / "zope.ini").read_text())
+        assert pipeline.index("translogger") < pipeline.index("dbg")
+        assert pipeline.index("dbg") < pipeline.index("egg:Zope#httpexceptions")
+
+
+def test_generic_filter_options_rendered_verbatim(cookies):
+    """options keys render as verbatim key = value lines in the filter block."""
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={
+            "wsgi_filters": {
+                "myfilter": {"use": "egg:foo#bar", "options": {"threshold": "5", "mode": "fast"}},
+            },
+        },
+    ) as result:
+        assert result.exit_code == 0
+        zope_ini = (result.project_path / "etc" / "zope.ini").read_text()
+        assert "[filter:myfilter]" in zope_ini
+        assert "use = egg:foo#bar" in zope_ini
+        assert "threshold = 5" in zope_ini
+        assert "mode = fast" in zope_ini

--- a/tests/test_bake_wsgi_filters.py
+++ b/tests/test_bake_wsgi_filters.py
@@ -72,3 +72,27 @@ def test_generic_filter_options_rendered_verbatim(cookies):
         assert "use = egg:foo#bar" in zope_ini
         assert "threshold = 5" in zope_ini
         assert "mode = fast" in zope_ini
+
+
+def test_reserved_filter_name_fails(cookies):
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={"wsgi_filters": {"zope": {"use": "egg:foo#bar"}}},
+    ) as result:
+        assert result.exit_code != 0
+
+
+def test_missing_use_fails(cookies):
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={"wsgi_filters": {"x": {"position": "outer"}}},
+    ) as result:
+        assert result.exit_code != 0
+
+
+def test_invalid_position_fails(cookies):
+    with bake_in_temp_dir(
+        cookies,
+        extra_context={"wsgi_filters": {"x": {"use": "egg:foo#bar", "position": "sideways"}}},
+    ) as result:
+        assert result.exit_code != 0

--- a/{{ cookiecutter.target }}/etc/zope.ini
+++ b/{{ cookiecutter.target }}/etc/zope.ini
@@ -19,42 +19,47 @@ max_request_body_size = {{ cookiecutter.wsgi_max_request_body_size }}
 channel_timeout = {{ cookiecutter.wsgi_channel_timeout }}
 {%- endif %}
 
+{#- === WSGI pipeline: build one ordered filter list, then render === -#}
+{%- set _outer = [] %}
+{%- set _inner = [] %}
+{%- for _name, _f in cookiecutter.wsgi_filters.items() %}
+{%-   set _spec = {'name': _name, 'use': _f.use, 'options': _f.get('options', {})} %}
+{%-   if _f.get('position', 'outer') == 'inner' %}
+{%-     set _ = _inner.append(_spec) %}
+{%-   else %}
+{%-     set _ = _outer.append(_spec) %}
+{%-   endif %}
+{%- endfor %}
+{%- set _builtin = [] %}
+{%- if cookiecutter.profile_repoze %}
+{%-   set _ = _builtin.append({'name': 'profile', 'use': 'egg:repoze.profile', 'options': {
+        'log_filename': cookiecutter.profile_repoze_log_filename | abspath,
+        'cachegrind_filename': cookiecutter.profile_repoze_cachegrind_filename | abspath,
+        'discard_first_request': cookiecutter.profile_repoze_discard_first_request,
+        'path': '/__profile__',
+        'flush_at_shutdown': cookiecutter.profile_repoze_flush_at_shutdown,
+        'unwind': cookiecutter.profile_repoze_unwind}}) %}
+{%- endif %}
 {%- if cookiecutter.access_log_enabled %}
-
-[filter:translogger]
-use = egg:Paste#translogger
-setup_console_handler = False
+{%-   set _ = _builtin.append({'name': 'translogger', 'use': 'egg:Paste#translogger', 'options': {'setup_console_handler': 'False'}}) %}
+{%- endif %}
+{%- set _pipeline = _outer + _builtin + _inner %}
 
 [pipeline:main]
 pipeline =
-{%- if cookiecutter.profile_repoze %}
-    profile
-{%- endif %}
-    translogger
+{%- for f in _pipeline %}
+    {{ f.name }}
+{%- endfor %}
     egg:Zope#httpexceptions
     zope
-{%- else %}
+{%- for f in _pipeline %}
 
-[pipeline:main]
-pipeline =
-{%- if cookiecutter.profile_repoze %}
-    profile
-{%- endif %}
-    egg:Zope#httpexceptions
-    zope
-{%- endif %}
-
-{%- if cookiecutter.profile_repoze %}
-
-[filter:profile]
-use = egg:repoze.profile
-log_filename = {{ cookiecutter.profile_repoze_log_filename | abspath }}
-cachegrind_filename = {{ cookiecutter.profile_repoze_cachegrind_filename | abspath }}
-discard_first_request = {{ cookiecutter.profile_repoze_discard_first_request }}
-path = /__profile__
-flush_at_shutdown = {{ cookiecutter.profile_repoze_flush_at_shutdown }}
-unwind = {{ cookiecutter.profile_repoze_unwind }}
-{%- endif %}
+[filter:{{ f.name }}]
+use = {{ f.use }}
+{%- for k, v in f.options.items() %}
+{{ k }} = {{ v }}
+{%- endfor %}
+{%- endfor %}
 {#- === Compute template variables === -#}
 {#- Active formatter -#}
 {%- if cookiecutter.log_format_class %}


### PR DESCRIPTION
## Summary

Adds a generic `wsgi_filters` option so users can inject arbitrary WSGI/PasteDeploy filters into the generated `zope.ini` pipeline — for example the request-metrics and OpenTelemetry middleware from [plone.observability](https://github.com/plone/plone.observability). Previously the pipeline was hardcoded with only two special-cased filters (`translogger` via `access_log_enabled`, `profile` via `profile_repoze`) and no extension point.

The built-in `profile`/`translogger` filters are migrated onto the **same unified render path** — they keep their public bool flags but are now expressed as regular filter specs.

## Public API

`wsgi_filters` is a dict `name → spec`, default `{}` (a top-level list is impossible in cookiecutter — it is interpreted as a choice menu; a dict is passed through untouched, like `product_config`):

```yaml
default_context:
  wsgi_filters:
    observability:
      use: "egg:plone.observability#observability"
    opentelemetry:
      use: "egg:plone.observability#opentelemetry"
```

Per entry: `use` (required), `options` (optional `key: value` map, verbatim), `position` (`outer` default — wraps everything; or `inner` — closest to the app). Reserved names: `zope`, `profile`, `translogger`, `httpexceptions`, `main`.

Pipeline order: `[outer] → profile? → translogger? → [inner] → egg:Zope#httpexceptions → zope`.

## Validation

`hooks/pre_gen_project.py` rejects reserved names, non-mapping values, missing `use`, and invalid `position` with a hard `exit(1)`.

## Backward compatibility

The migration changes the *order of sections* in `zope.ini` (PasteDeploy is order-insensitive) but keeps the `[pipeline:main]` entries and `[filter:*]` block contents identical for existing configs. The entire pre-existing test suite stays green; the `profile_repoze=true` render (incl. `abspath` paths) was verified manually.

## Tests

New `tests/test_bake_wsgi_filters.py`: generic outer filter, `position: inner`, verbatim `options`, and negative cases (reserved name / missing `use` / invalid `position`). Full suite: 70 passed.

## Docs

- Reference: `wsgi_filters` documented in `basic-config.md`.
- New how-to: `add-wsgi-middleware.md` (with plone.observability example), registered in the how-to index.
- `CHANGES.md` entry under 3.0.3 (unreleased).

🤖 Generated with [Claude Code](https://claude.com/claude-code)